### PR TITLE
feat(display): Add optional full refresh timer.

### DIFF
--- a/app/src/display/Kconfig
+++ b/app/src/display/Kconfig
@@ -71,6 +71,13 @@ endchoice
 
 endif # ZMK_DISPLAY_STATUS_SCREEN_BUILT_IN
 
+config ZMK_DISPLAY_FULL_REFRESH_PERIOD
+    int "(Optional) Period to issue a full refresh to the display (in seconds)"
+    default 0
+    help
+      Period in seconds for how often to completely refresh/redraw the whole screen.
+      Most useful for e-ink/EPD displays that require occasional full redraws.
+
 rsource "widgets/Kconfig"
 
 endif


### PR DESCRIPTION
* Useful for EPD that ghost after several partial updates. Only a temporary fix, tracking number of partial updates and triggering full refreshes based on that would be better.

<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->
## Board/Shield Check-list
 - [ ] This board/shield is tested working on real hardware
 - [ ] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
 - [ ] `.zmk.yml` metadata file added
 - [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
 - [ ] General consistent formatting of DeviceTree files
 - [ ] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
 - [ ] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
 - [ ] If split, no name added for the right/peripheral half
 - [ ] Kconfig.defconfig file correctly wraps *all* configuration in conditional on the shield symbol
 - [ ] `.conf` file has optional extra features commented out
 - [ ] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
